### PR TITLE
Upgrade to nom 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "bittorrent"
 version = "0.1.0"
 dependencies = [
- "nom 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 1.0.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nom"
-version = "0.3.0"
+version = "1.0.0-alpha2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["J. Aaron Gustafson <jag426@cornell.edu>"]
 
 [dependencies]
-nom = "~0.3.0"
+nom = "~1.0.0"
 sha1 = "0.1.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(collections, collections_drain, test)]
+#![feature(test,vec_push_all,drain)]
 
 extern crate test;
 
@@ -55,7 +55,7 @@ fn text(i: &[u8]) -> IResult<&[u8], Vec<u8>> {
         IResult::Done(rest, n) => {
             let n = n as usize;
             if rest.len() < n+1 {
-                IResult::Incomplete(Needed::Size((n+1) as u32))
+                IResult::Incomplete(Needed::Size(n+1))
             } else {
                 let mut v = vec!();
                 v.push_all(&rest[1..n+1]);


### PR DESCRIPTION
Hi!

nom 1.0 is here, and comes with a few breaking changes. To help the transition, and to test the beta version before release, I took the liberty to test and upgrade (if needed) your code to the 1.0 version. It should work right away, but if there are still issues, or if the code needs to be updated to your latest master, please let me know!

If you want an explanation of the changes, please take a look at the [upgrading documentation](https://github.com/Geal/nom/wiki/Upgrading-to-nom-1.0).

By the way, could you go to one (or all) of those links and write a few kind words about your experience writing parsers in Rust? It would really help me!

* [nom 1.0 release blogpost](https://www.clever-cloud.com/blog/engineering/2015/11/16/nom-1-0/)
* [Reddit post](https://www.reddit.com/r/rust/comments/3t10f3/nom_just_reached_10_cleaner_parsers_more_generic/)
* [Hacker News post](https://news.ycombinator.com/item?id=10574828)

Thank you for using nom!